### PR TITLE
Bash fix and tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Currently planned features include the following:
    with GitHub in order to notify Jekyll's developers of performance
    regressions.
 
+## How to use the `generate_site.sh` script
+
+You can run the script straight from the cloned repository using
+
+    bash generate_site.sh X .
+
+...where `X` is the number of posts you want to generate.
+
+If you want to test the various Jekyll plugins and how they affect the 
+build, you'll need to do the following:
+ - Run a couple of tests on the clean installation to have some basic
+   values to work with (increase `X` incrementally to do this).
+ - Create a `_plugins` folder and put the `.rb` file of the plugin there.
+ - Run the tests using the same `X` values as you've used in the
+   bare installation.
+ - Compare the results of those two sets of tests.
+
 ## License
 
 MIT. See the LICENSE file for more details

--- a/generate_site.sh
+++ b/generate_site.sh
@@ -42,7 +42,7 @@ EOF
 for post_number in `seq 1 $POST_COUNT`
 do
     export POST_NUMBER=$post_number
-    post_date=`date -v -${post_number}d +%Y-%m-%d`
+    post_date=`date +%Y-%m-%d`
     post_file="$post_date-test_post_$post_number"
     cat >$POST_DIR/$post_file.md << EOF
 ---


### PR DESCRIPTION
## What this PR does

It fixes the bash script and adds the basic instructions on how to run the bash script to the README file.
## Why does this PR change the bash script

I failed to run it on Ubuntu 16.04 (using 8.25 version of the `date` command) because this version of the `date` command does not recognize the `-v` flag.
## Why does this PR change the README file

While I was trying to run this basic bash script (which _did_ help us a lot because of some performance issues we are having), I had no idea how to do it. All I got was an error saying that it needs two arguments. So, after I took a look at the script itself, I was able to figure it out. I guess that other people don't really need to take a look at the script and be able to understand it to be able to run it.
